### PR TITLE
ci: auto-publish @plantquest/model-vue@dev on develop merges

### DIFF
--- a/.github/workflows/publish-dev-tag.yml
+++ b/.github/workflows/publish-dev-tag.yml
@@ -1,0 +1,81 @@
+name: Publish dev dist-tag
+
+# Fires on every merge to develop (and can be manually re-run by any team member).
+# Sequence:
+#   1. Bump patch version in package.json  (repo-version:dev — preserves -demo-dev suffix)
+#   2. Commit + push version bump back to develop  [skip ci]
+#   3. Build the library  (vue-cli-service build --target lib)
+#   4. Force-push git tag 'dev' to develop HEAD
+#   5. npm run repo-npm-tag:dev  (publishes if new, or moves the dev dist-tag if already on npm)
+#   6. Trigger system-demo demo-dev deployment
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-model-vue-dev
+  cancel-in-progress: false  # never cancel mid-publish; queue instead
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # GH_PAT needed to push commits and force-push tags back to develop
+          token: ${{ secrets.GH_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure git identity
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Bump patch version
+        # repo-version:dev increments the numeric patch and preserves any pre-release
+        # suffix (e.g. -demo-dev) so the version stays in the correct format.
+        run: npm run repo-version:dev
+
+      - name: Commit and push version bump
+        run: |
+          git add package.json
+          git commit -m "chore: bump dev version [skip ci]"
+          git push origin develop
+
+      - name: Build library
+        # Vue CLI 4.x / Webpack 4 requires --openssl-legacy-provider on Node 18+
+        run: npm run vue-build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Push dev git tag to develop HEAD
+        run: npm run repo-tag:dev && git push origin refs/tags/dev --force
+
+      - name: Publish to npm with dev dist-tag
+        # repo-npm-tag:dev is smart: if this version is already on npm it moves the
+        # dist-tag; otherwise it publishes fresh with --tag dev.
+        run: npm run repo-npm-tag:dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Trigger system-demo demo-dev deploy
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh workflow run deploy-system-demo-frontend.yml \
+            --repo plantquest/system-demo \
+            --ref develop

--- a/.github/workflows/publish-dev-tag.yml
+++ b/.github/workflows/publish-dev-tag.yml
@@ -8,6 +8,14 @@ name: Publish dev dist-tag
 #   4. Force-push git tag 'dev' to develop HEAD
 #   5. npm run repo-npm-tag:dev  (publishes if new, or moves the dev dist-tag if already on npm)
 #   6. Trigger system-demo demo-dev deployment
+#
+# Authentication: npm OIDC Trusted Publishing — no NPM_TOKEN stored in secrets.
+# One-time setup required in your npm account:
+#   npmjs.com → Account Settings → Trusted Publishers → Add publisher
+#     Provider : GitHub Actions
+#     Owner    : plantquest
+#     Repo     : model-vue
+#     Workflow : publish-dev-tag.yml
 on:
   push:
     branches: [develop]
@@ -15,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # required for npm OIDC trusted publishing
 
 concurrency:
   group: publish-model-vue-dev
@@ -34,6 +43,8 @@ jobs:
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
+          # With id-token:write above, setup-node exchanges the GitHub OIDC token
+          # for a short-lived npm publish token — no NPM_TOKEN secret required.
 
       - name: Configure git identity
         run: |
@@ -41,9 +52,8 @@ jobs:
           git config user.name "github-actions[bot]"
 
       - name: Install dependencies
+        # @plantquest packages are publicly accessible — no auth token needed for install.
         run: npm install --legacy-peer-deps
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump patch version
         # repo-version:dev increments the numeric patch and preserves any pre-release
@@ -67,10 +77,12 @@ jobs:
 
       - name: Publish to npm with dev dist-tag
         # repo-npm-tag:dev is smart: if this version is already on npm it moves the
-        # dist-tag; otherwise it publishes fresh with --tag dev.
+        # dist-tag via 'npm dist-tag add'; otherwise it publishes fresh with --tag dev.
+        # NPM_CONFIG_PROVENANCE=true enables the OIDC attestation required by
+        # npm Trusted Publishing (equivalent to 'npm publish --provenance').
         run: npm run repo-npm-tag:dev
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Trigger system-demo demo-dev deploy
         env:


### PR DESCRIPTION
Adds `.github/workflows/publish-dev-tag.yml`.

## What this does
On every merge to `develop` (and via `workflow_dispatch`):
1. Bumps the patch version (`repo-version:dev` — preserves the `-demo-dev` suffix)
2. Commits + pushes version bump back to `develop` with `[skip ci]`
3. Builds the library (`vue-build` with `NODE_OPTIONS=--openssl-legacy-provider`)
4. Force-pushes git tag `dev` to develop HEAD
5. Publishes `@plantquest/model-vue@dev` to npm (or moves the dist-tag if already published)
6. Triggers `deploy-system-demo-frontend.yml` on `plantquest/system-demo`

## Secrets required in this repo
- `GH_PAT` — PAT with `repo` + `workflow` scope (used to push commits/tags and trigger system-demo)
- `NPM_TOKEN` — npm auth token with publish access to `@plantquest/model-vue`

Made with [Cursor](https://cursor.com)